### PR TITLE
Fixed ambiguous db name and broken transactions

### DIFF
--- a/libraries/UpgradeToOmekaS/Helper/Target.php
+++ b/libraries/UpgradeToOmekaS/Helper/Target.php
@@ -194,10 +194,12 @@ class UpgradeToOmekaS_Helper_Target
 
         if (!isset($this->_tablesColumns[$table])) {
             $db = $this->getDb();
+            $config = $db->getConfig();
+            $dbname = isset($config['dbname']) ? $config['dbname'] : '';
             $sql = '
             SELECT COLUMN_NAME
             FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_NAME = ' . $db->quote($table) . ';';
+            WHERE TABLE_SCHEMA = ' . $db->quote($dbname) . ' AND TABLE_NAME = ' . $db->quote($table) . ';';
             $result = $db->fetchCol($sql);
             $this->_tablesColumns[$table] = $result;
         }
@@ -354,13 +356,11 @@ class UpgradeToOmekaS_Helper_Target
             unset($rows);
         }
 
-        // Prepare the transaction.
-        $sql = 'BEGIN;' . PHP_EOL;
+        // Prepare the insert statements 
         foreach ($rowsByTable as $table => $rows) {
             $sql .= sprintf('INSERT INTO `%s` (`%s`) VALUES ', $table, implode('`, `', $columns[$table])) . PHP_EOL;
             $sql .= '(' . implode('),' . PHP_EOL . '(', $rows) . ');' . PHP_EOL;
         }
-        $sql .= 'COMMIT;' . PHP_EOL;
 
         $db = $this->getDb();
         $result = $db->prepare($sql)->execute();


### PR DESCRIPTION
Hi, thanks for excellent plugin!
I tested it with sample data in Omeka Classic and found 2 errors that this PR fixes.
1. getting cols for `user` table conflicts with `mysql.user` table, so it was not possible to migrate users. So schema is important
2. I received MySQL error: **Lock wait timeout exceeded; try restarting transaction** when updating hashes for media. After lot of searching and debugging I tried to disable the transaction block and got new error from *ExhibitBuilder* migration related to Omeka S `site_block_attachment` table, that `caption` cannot be null. After fixing that all worked fine. So it's clear, when running multiple inserts in transaction block like this, if any of insert fails, it doesn't fire exception and the transaction is not comitted. And then comes this *Lock wait timeout* issue. So I think it's safer not to use `BEGIN; ... COMMIT;` block and rely on standard mysql `autocommit` config.